### PR TITLE
Use @tobyink's test vocab

### DIFF
--- a/lib/Test/FITesque/RDF.pm
+++ b/lib/Test/FITesque/RDF.pm
@@ -56,9 +56,10 @@ sub _build_suite {
 sub transform_rdf {
   my $self = shift;
   my $ns = URI::NamespaceMap->new(['deps', 'dc', 'rdf']);
-  $ns->add_mapping(test => 'http://example.org/test-fixtures#'); # TODO: Get a proper URI
+  $ns->add_mapping(test => 'http://ontologi.es/doap-tests#');
   $ns->add_mapping(http => 'http://www.w3.org/2007/ont/http#');
   $ns->add_mapping(httph => 'http://www.w3.org/2007/ont/httph#');
+  $ns->add_mapping(nfo => 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#');
   my $parser = Attean->get_parser(filename => $self->source)->new( base => $self->base_uri );
   my $model = Attean->temporary_model;
 
@@ -93,10 +94,10 @@ sub transform_rdf {
 		$params_base = URI::Namespace->new($params_base_term);
 		$ns->guess_and_add($params_base);
 	 }
-	 my $test_bgp = bgp(triplepattern($test_uri, iri($ns->rdf->type->as_string), variable('handler_class')),
-							  triplepattern(variable('handler_class'), iri($ns->deps->iri('test-requirement')->as_string), variable('handler')), # Because Perl doesn't support dashes in method names
-							  triplepattern($test_uri, iri($ns->test->script->as_string), variable('method')),
-							  triplepattern($test_uri, iri($ns->dc->description->as_string), variable('description')),
+	 my $test_bgp = bgp(triplepattern($test_uri, iri($ns->test->test_script->as_string), variable('script_class')),
+							  triplepattern(variable('script_class'), iri($ns->deps->iri('test-requirement')->as_string), variable('handler')), # Because Perl doesn't support dashes in method names
+							  triplepattern(variable('script_class'), iri($ns->nfo->definesFunction->as_string), variable('method')),
+							  triplepattern($test_uri, iri($ns->test->purpose->as_string), variable('description')),
 							  triplepattern($test_uri, iri($ns->test->params->as_string), variable('paramid')));
 
 	 my $algebra = Attean::Algebra::Query->new(children => [$test_bgp]); # TODO: generalize the next 4 lines in Attean

--- a/t/data/http-list-multi.ttl
+++ b/t/data/http-list-multi.ttl
@@ -10,9 +10,9 @@
     test:fixtures ( <#public-writeread-unauthn-alt> <#public-cors-origin-set> ).
 
 
-<#public-writeread-unauthn-alt> a <http://example.org/HTTPListTest>  ;
+<#public-writeread-unauthn-alt> a test:AutomatedTest  ;
     dc:description "More elaborate HTTP vocab for PUT then GET test"@en ;
-    test:script "http_req_res_list_unauthenticated" ;
+    test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
         test:requests ( <#public-writeread-unauthn-alt-put-req> <#public-writeread-unauthn-alt-get-req> ) ;
         test:responses ( <#public-writeread-unauthn-alt-put-res> <#public-writeread-unauthn-alt-get-res> ) 
@@ -37,9 +37,9 @@
             
 
 
-<#public-cors-origin-set> a <http://example.org/HTTPListTest>  ;
+<#public-cors-origin-set> a test:AutomatedTest  ;
     dc:description "Testing CORS header when Origin is supplied by client"@en ;
-    test:script "http_req_res_list_unauthenticated" ;
+    test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
         test:requests ( <#public-cors-origin-set-req> ) ;
         test:responses ( <#public-cors-origin-set-res> ) 
@@ -56,6 +56,6 @@
                     httph:content_type "text/turtle" .
             
 
-<http://example.org/HTTPListTest> rdfs:subClassOf test:ScriptClass ;
-    deps:test-requirement "Internal::Fixture::HTTPList"^^deps:CpanId .
-                        
+<http://example.org/httplist#http_req_res_list_unauthenticated> a nfo:SoftwareItem ;
+            deps:test-requirement "Internal::Fixture::HTTPList"^^deps:CpanId ;
+            nfo:definesFunction "http_req_res_list_unauthenticated" .

--- a/t/data/http-list-multi.ttl
+++ b/t/data/http-list-multi.ttl
@@ -11,7 +11,7 @@
 
 
 <#public-writeread-unauthn-alt> a test:AutomatedTest  ;
-    dc:description "More elaborate HTTP vocab for PUT then GET test"@en ;
+    test:purpose "More elaborate HTTP vocab for PUT then GET test"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
         test:requests ( <#public-writeread-unauthn-alt-put-req> <#public-writeread-unauthn-alt-get-req> ) ;
@@ -38,7 +38,7 @@
 
 
 <#public-cors-origin-set> a test:AutomatedTest  ;
-    dc:description "Testing CORS header when Origin is supplied by client"@en ;
+    test:purpose "Testing CORS header when Origin is supplied by client"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
         test:requests ( <#public-cors-origin-set-req> ) ;

--- a/t/data/http-list-multi.ttl
+++ b/t/data/http-list-multi.ttl
@@ -1,9 +1,9 @@
-@prefix test: <http://example.org/test-fixtures#> .
+@prefix test: <http://ontologi.es/doap-tests#> .
 @prefix deps: <http://ontologi.es/doap-deps#>.
 @prefix dc:   <http://purl.org/dc/terms/> .
 @prefix httph:<http://www.w3.org/2007/ont/httph#> .
 @prefix http: <http://www.w3.org/2007/ont/http#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 
 
 <#test-list> a test:FixtureTable ;

--- a/t/data/http-list.ttl
+++ b/t/data/http-list.ttl
@@ -1,18 +1,17 @@
-@prefix test: <http://example.org/test-fixtures#> .
+@prefix test: <http://ontologi.es/doap-tests#> .
 @prefix deps: <http://ontologi.es/doap-deps#>.
-@prefix dc:   <http://purl.org/dc/terms/> .
 @prefix httph:<http://www.w3.org/2007/ont/httph#> .
 @prefix http: <http://www.w3.org/2007/ont/http#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 
 
 <#test-list> a test:FixtureTable ;
     test:fixtures <#public-writeread-unauthn-alt> .
 
 
-<#public-writeread-unauthn-alt> a <http://example.org/HTTPListTest>  ;
-    dc:description "More elaborate HTTP vocab for PUT then GET test"@en ;
-    test:script "http_req_res_list_unauthenticated" ;
+<#public-writeread-unauthn-alt> a test:AutomatedTest ;
+    test:purpose "More elaborate HTTP vocab for PUT then GET test"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
         test:requests ( <#public-writeread-unauthn-alt-put-req> <#public-writeread-unauthn-alt-get-req> ) ;
         test:responses ( <#public-writeread-unauthn-alt-put-res> <#public-writeread-unauthn-alt-get-res> ) 
@@ -37,6 +36,6 @@
             httph:content_type "text/turtle" .
             
 
-<http://example.org/HTTPListTest> rdfs:subClassOf test:ScriptClass ;
-            deps:test-requirement "Internal::Fixture::HTTPList"^^deps:CpanId .
-            
+<http://example.org/httplist#http_req_res_list_unauthenticated> a nfo:SoftwareItem ;
+            deps:test-requirement "Internal::Fixture::HTTPList"^^deps:CpanId ;
+            nfo:definesFunction "http_req_res_list_unauthenticated" .

--- a/t/data/list.ttl
+++ b/t/data/list.ttl
@@ -18,7 +18,7 @@
 <#test2> a <http://example.org/MultiTest> ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Multiply two numbers"@en ;
-    test:script "multiplication" ;
+    test:test_script <http://example.org/multi#multiplication> ;
     test:params [
         my:factor1 6 ;
         my:factor2 7 ;
@@ -29,5 +29,6 @@
     nfo:definesFunction "string_found" ;
     deps:test-requirement "Internal::Fixture::Simple"^^deps:CpanId .
 
-<http://example.org/MultiTest> rdfs:subClassOf test:ScriptClass ;
+<http://example.org/multi#multiplication> a nfo:SoftwareItem ;
+    nfo:definesFunction "multiplication" ;
     deps:test-requirement "Internal::Fixture::Multi"^^deps:CpanId .

--- a/t/data/list.ttl
+++ b/t/data/list.ttl
@@ -12,7 +12,7 @@
 <#test1> a <http://example.org/SimpleTest> ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Echo a string"@en ;
-    test:script "string_found" ;
+    test:test_script <http://example.org/simple#string_found> ;
     test:params [ my:all "counter-clockwise dahut" ] .
 
 <#test2> a <http://example.org/MultiTest> ;
@@ -25,7 +25,8 @@
         my:product 42 
     ] .
         
-<http://example.org/SimpleTest> rdfs:subClassOf test:ScriptClass ;
+<http://example.org/simple#string_found> a nfo:SoftwareItem ;
+    nfo:definesFunction "string_found" ;
     deps:test-requirement "Internal::Fixture::Simple"^^deps:CpanId .
 
 <http://example.org/MultiTest> rdfs:subClassOf test:ScriptClass ;

--- a/t/data/list.ttl
+++ b/t/data/list.ttl
@@ -9,13 +9,13 @@
 <#test-list> a test:FixtureTable ;
     test:fixtures ( <#test1> <#test2> ) .
 
-<#test1> a <http://example.org/SimpleTest> ;
+<#test1> a test:AutomatedTest ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Echo a string"@en ;
     test:test_script <http://example.org/simple#string_found> ;
     test:params [ my:all "counter-clockwise dahut" ] .
 
-<#test2> a <http://example.org/MultiTest> ;
+<#test2> a test:AutomatedTest ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Multiply two numbers"@en ;
     test:test_script <http://example.org/multi#multiplication> ;

--- a/t/data/list.ttl
+++ b/t/data/list.ttl
@@ -11,13 +11,13 @@
 
 <#test1> a <http://example.org/SimpleTest> ;
     test:param_base <http://example.org/my-parameters#> ;
-    dc:description "Echo a string"@en ;
+    test:purpose "Echo a string"@en ;
     test:script "string_found" ;
     test:params [ my:all "counter-clockwise dahut" ] .
 
 <#test2> a <http://example.org/MultiTest> ;
     test:param_base <http://example.org/my-parameters#> ;
-    dc:description "Multiply two numbers"@en ;
+    test:purpose "Multiply two numbers"@en ;
     test:script "multiplication" ;
     test:params [
         my:factor1 6 ;

--- a/t/data/list.ttl
+++ b/t/data/list.ttl
@@ -1,8 +1,8 @@
-@prefix test: <http://example.org/test-fixtures#> .
+@prefix test: <http://ontologi.es/doap-tests#> .
 @prefix deps: <http://ontologi.es/doap-deps#>.
 @prefix dc:   <http://purl.org/dc/terms/> .
 @prefix my:   <http://example.org/my-parameters#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 
 
 

--- a/t/data/multi-vocab.ttl
+++ b/t/data/multi-vocab.ttl
@@ -11,12 +11,12 @@
 <#test1> a <http://example.org/SimpleTest> ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Echo a string"@en ;
-    test:script "multi_vocabs" ;
+    test:test_script <http://example.org/simple#multi_vocabs> ;
     test:params [
         my:all "counter-clockwise dahut" ;
         <http://example.org/other-vocab#foo> 42 
         ] .
 
-<http://example.org/simple#string_found> a nfo:SoftwareItem ;
-    nfo:definesFunction "string_found" ;
+<http://example.org/simple#multi_vocabs> a nfo:SoftwareItem ;
+    nfo:definesFunction "multi_vocabs" ;
     deps:test-requirement "Internal::Fixture::Simple"^^deps:CpanId .

--- a/t/data/multi-vocab.ttl
+++ b/t/data/multi-vocab.ttl
@@ -10,7 +10,7 @@
 
 <#test1> a <http://example.org/SimpleTest> ;
     test:param_base <http://example.org/my-parameters#> ;
-    dc:description "Echo a string"@en ;
+    test:purpose "Echo a string"@en ;
     test:script "multi_vocabs" ;
     test:params [
         my:all "counter-clockwise dahut" ;

--- a/t/data/multi-vocab.ttl
+++ b/t/data/multi-vocab.ttl
@@ -8,7 +8,7 @@
 <#test-list> a test:FixtureTable ;
     test:fixtures <#test1> . 
 
-<#test1> a <http://example.org/SimpleTest> ;
+<#test1> a test:AutomatedTest ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Echo a string"@en ;
     test:test_script <http://example.org/simple#multi_vocabs> ;

--- a/t/data/multi-vocab.ttl
+++ b/t/data/multi-vocab.ttl
@@ -1,8 +1,8 @@
-@prefix test: <http://example.org/test-fixtures#> .
+@prefix test: <http://ontologi.es/doap-tests#> .
 @prefix deps: <http://ontologi.es/doap-deps#>.
 @prefix dc:   <http://purl.org/dc/terms/> .
 @prefix my:   <http://example.org/my-parameters#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 
 
 <#test-list> a test:FixtureTable ;

--- a/t/data/multi-vocab.ttl
+++ b/t/data/multi-vocab.ttl
@@ -17,5 +17,6 @@
         <http://example.org/other-vocab#foo> 42 
         ] .
 
-<http://example.org/SimpleTest> rdfs:subClassOf test:ScriptClass ;
+<http://example.org/simple#string_found> a nfo:SoftwareItem ;
+    nfo:definesFunction "string_found" ;
     deps:test-requirement "Internal::Fixture::Simple"^^deps:CpanId .

--- a/t/data/multi.ttl
+++ b/t/data/multi.ttl
@@ -1,8 +1,8 @@
-@prefix test: <http://example.org/test-fixtures#> .
+@prefix test: <http://ontologi.es/doap-tests#> .
 @prefix deps: <http://ontologi.es/doap-deps#>.
 @prefix dc:   <http://purl.org/dc/terms/> .
 @prefix my:   <http://example.org/my-parameters#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 
 
 <#test-list> a test:FixtureTable ;

--- a/t/data/multi.ttl
+++ b/t/data/multi.ttl
@@ -8,13 +8,13 @@
 <#test-list> a test:FixtureTable ;
     test:fixtures <#test1>, <#test2> . 
 
-<#test1> a <http://example.org/SimpleTest> ;
+<#test1> a test:AutomatedTest ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Echo a string"@en ;    
     test:test_script <http://example.org/simple#string_found> ;
     test:params [ my:all "counter-clockwise dahut" ] .
         
-<#test2> a <http://example.org/MultiTest> ;
+<#test2> a test:AutomatedTest ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Multiply two numbers"@en ;
     test:test_script <http://example.org/multi#multiplication> ;

--- a/t/data/multi.ttl
+++ b/t/data/multi.ttl
@@ -10,13 +10,13 @@
 
 <#test1> a <http://example.org/SimpleTest> ;
     test:param_base <http://example.org/my-parameters#> ;
-    dc:description "Echo a string"@en ;    
+    test:purpose "Echo a string"@en ;    
     test:script "string_found" ;
     test:params [ my:all "counter-clockwise dahut" ] .
         
 <#test2> a <http://example.org/MultiTest> ;
     test:param_base <http://example.org/my-parameters#> ;
-    dc:description "Multiply two numbers"@en ;
+    test:purpose "Multiply two numbers"@en ;
     test:script "multiplication" ;
     test:params [
         my:factor1 6 ;

--- a/t/data/multi.ttl
+++ b/t/data/multi.ttl
@@ -11,7 +11,7 @@
 <#test1> a <http://example.org/SimpleTest> ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Echo a string"@en ;    
-    test:script "string_found" ;
+    test:test_script <http://example.org/simple#string_found> ;
     test:params [ my:all "counter-clockwise dahut" ] .
         
 <#test2> a <http://example.org/MultiTest> ;
@@ -24,7 +24,8 @@
         my:product 42 
     ] .
         
-<http://example.org/SimpleTest> rdfs:subClassOf test:ScriptClass ;
+<http://example.org/simple#string_found> a nfo:SoftwareItem ;
+    nfo:definesFunction "string_found" ;
     deps:test-requirement "Internal::Fixture::Simple"^^deps:CpanId .
 
 <http://example.org/MultiTest> rdfs:subClassOf test:ScriptClass ;

--- a/t/data/multi.ttl
+++ b/t/data/multi.ttl
@@ -17,7 +17,7 @@
 <#test2> a <http://example.org/MultiTest> ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Multiply two numbers"@en ;
-    test:script "multiplication" ;
+    test:test_script <http://example.org/multi#multiplication> ;
     test:params [
         my:factor1 6 ;
         my:factor2 7 ;
@@ -28,5 +28,6 @@
     nfo:definesFunction "string_found" ;
     deps:test-requirement "Internal::Fixture::Simple"^^deps:CpanId .
 
-<http://example.org/MultiTest> rdfs:subClassOf test:ScriptClass ;
+<http://example.org/multi#multiplication> a nfo:SoftwareItem ;
+    nfo:definesFunction "multiplication" ;
     deps:test-requirement "Internal::Fixture::Multi"^^deps:CpanId .

--- a/t/data/relative.ttl
+++ b/t/data/relative.ttl
@@ -14,5 +14,6 @@
     test:script "relative_uri" ;
     test:params [ my:url </foo/> ] .
         
-<http://example.org/SimpleTest> rdfs:subClassOf test:ScriptClass ;
+<http://example.org/simple#string_found> a nfo:SoftwareItem ;
+    nfo:definesFunction "string_found" ;
     deps:test-requirement "Internal::Fixture::Simple"^^deps:CpanId .

--- a/t/data/relative.ttl
+++ b/t/data/relative.ttl
@@ -1,8 +1,8 @@
-@prefix test: <http://example.org/test-fixtures#> .
+@prefix test: <http://ontologi.es/doap-tests#> .
 @prefix deps: <http://ontologi.es/doap-deps#>.
 @prefix dc:   <http://purl.org/dc/terms/> .
 @prefix my:   <http://example.org/my-parameters#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 
 
 <#test-list> a test:FixtureTable ;

--- a/t/data/relative.ttl
+++ b/t/data/relative.ttl
@@ -8,7 +8,7 @@
 <#test-list> a test:FixtureTable ;
     test:fixtures <#test1> . 
 
-<#test1> a <http://example.org/SimpleTest> ;
+<#test1> a test:AutomatedTest ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Check that a relative URI resolves"@en ;
     test:test_script <http://example.org/simple#relative_uri> ;

--- a/t/data/relative.ttl
+++ b/t/data/relative.ttl
@@ -11,9 +11,9 @@
 <#test1> a <http://example.org/SimpleTest> ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Check that a relative URI resolves"@en ;
-    test:script "relative_uri" ;
+    test:test_script <http://example.org/simple#relative_uri> ;
     test:params [ my:url </foo/> ] .
         
-<http://example.org/simple#string_found> a nfo:SoftwareItem ;
-    nfo:definesFunction "string_found" ;
+<http://example.org/simple#relative_uri> a nfo:SoftwareItem ;
+    nfo:definesFunction "relative_uri" ;
     deps:test-requirement "Internal::Fixture::Simple"^^deps:CpanId .

--- a/t/data/relative.ttl
+++ b/t/data/relative.ttl
@@ -10,7 +10,7 @@
 
 <#test1> a <http://example.org/SimpleTest> ;
     test:param_base <http://example.org/my-parameters#> ;
-    dc:description "Check that a relative URI resolves"@en ;
+    test:purpose "Check that a relative URI resolves"@en ;
     test:script "relative_uri" ;
     test:params [ my:url </foo/> ] .
         

--- a/t/data/simple.ttl
+++ b/t/data/simple.ttl
@@ -10,9 +10,10 @@
 <#test1> a  <http://example.org/SimpleTest> ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Echo a string"@en ;    
-    test:script "string_found" ;
+    test:test_script <http://example.org/simple#string_found> ;
     test:params [ my:all "counter-clockwise dahut" ] .
         
-<http://example.org/SimpleTest> rdfs:subClassOf test:ScriptClass ;
+<http://example.org/simple#string_found> a nfo:SoftwareItem ;
+    nfo:definesFunction "string_found" ;
     deps:test-requirement "Internal::Fixture::Simple"^^deps:CpanId .
     

--- a/t/data/simple.ttl
+++ b/t/data/simple.ttl
@@ -9,7 +9,7 @@
 
 <#test1> a  <http://example.org/SimpleTest> ;
     test:param_base <http://example.org/my-parameters#> ;
-    dc:description "Echo a string"@en ;    
+    test:purpose "Echo a string"@en ;    
     test:script "string_found" ;
     test:params [ my:all "counter-clockwise dahut" ] .
         

--- a/t/data/simple.ttl
+++ b/t/data/simple.ttl
@@ -7,7 +7,7 @@
 <#test-list> a test:FixtureTable ;
     test:fixtures <#test1> . 
 
-<#test1> a  <http://example.org/SimpleTest> ;
+<#test1> a  test:AutomatedTest ;
     test:param_base <http://example.org/my-parameters#> ;
     test:purpose "Echo a string"@en ;    
     test:test_script <http://example.org/simple#string_found> ;

--- a/t/data/simple.ttl
+++ b/t/data/simple.ttl
@@ -1,8 +1,8 @@
-@prefix test: <http://example.org/test-fixtures#> .
+@prefix test: <http://ontologi.es/doap-tests#> .
 @prefix deps: <http://ontologi.es/doap-deps#>.
 @prefix dc:   <http://purl.org/dc/terms/> .
 @prefix my:   <http://example.org/my-parameters#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 
 <#test-list> a test:FixtureTable ;
     test:fixtures <#test1> . 


### PR DESCRIPTION
I found @tobyink's test vocab http://ontologi.es/doap-tests# can work for us with minor additions. 

It is an improvement over the previous structure in a few respects. One is that it reuses existing vocabs, another that it separates out the references to implementation alltogether (which is how @tobyink constructured it). Also, I felt that using a class to reference the Perl class wasn't a good fit, after all, the Perl class may end up just being a bag of scripts, and doesn't fit the rigor of an RDF class. 

There is a possible, little drawback, and that it is that this use of the two predicates used to reference the implementation doesn't 100% match the semantics of the authors of the vocabs intended. I think it is good enough, we shouldn't need to introduce new predicates for that reason.