### PR TITLE
Mix HTTP parameters and other parameters

### DIFF
--- a/lib/Test/FITesque/RDF.pm
+++ b/lib/Test/FITesque/RDF.pm
@@ -164,7 +164,8 @@ sub transform_rdf {
 				push(@responses, $res);
 			 }
 			 $params->{'http-responses'} = \@responses;
-		  } else {
+		  }
+		  if ($param->object->is_literal || $param->object->is_iri) {
 			 my $key = $param->predicate->as_string;
 			 if (defined($params_base) && $params_base->local_part($param->predicate)) {
 				$key = $params_base->local_part($param->predicate)

--- a/t/data/http-mix.ttl
+++ b/t/data/http-mix.ttl
@@ -1,0 +1,34 @@
+@prefix test: <http://ontologi.es/doap-tests#> .
+@prefix deps: <http://ontologi.es/doap-deps#>.
+@prefix httph:<http://www.w3.org/2007/ont/httph#> .
+@prefix http: <http://www.w3.org/2007/ont/http#> .
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix my:   <http://example.org/my-parameters#> .
+
+<#test-list> a test:FixtureTable ;
+    test:fixtures <#public-mix> .
+
+
+<#public-mix> a test:AutomatedTest ;
+    test:purpose "Mix HTTP and ordinary params."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
+    test:param_base <http://example.org/my-parameters#> ;
+    test:params [
+        my:user "alice" ;
+        test:requests ( <#public-writeread-unauthn-alt-get-req> ) ;
+        test:responses ( <#public-writeread-unauthn-alt-get-res> ) 
+                ] .
+                
+
+<#public-writeread-unauthn-alt-get-req> a http:RequestMessage ;
+    http:method "GET" ;
+    http:requestURI </public/foobar.ttl> .
+            
+<#public-writeread-unauthn-alt-get-res> a http:ResponseMessage ;
+            httph:accept_post  "text/turtle", "application/ld+json" ;
+            httph:content_type "text/turtle" .
+            
+
+<http://example.org/httplist#http_req_res_list_unauthenticated> a nfo:SoftwareItem ;
+            deps:test-requirement "Internal::Fixture::HTTPList"^^deps:CpanId ;
+            nfo:definesFunction "http_req_res_list_unauthenticated" .

--- a/t/unit-http-mix.t
+++ b/t/unit-http-mix.t
@@ -4,7 +4,7 @@
 
 =head1 PURPOSE
 
-Unit test that Test::FITesque::RDF transforms HTTP data correctly from RDF
+Unit test that Test::FITesque::RDF transforms both basic key-value parameters and HTTP data correctly from RDF
 
 =head1 AUTHOR
 

--- a/t/unit-http-mix.t
+++ b/t/unit-http-mix.t
@@ -42,7 +42,7 @@ my $t = object_ok(
 
 
 my $data = $t->transform_rdf;
-#warn Data::Dumper::Dumper($data);
+
 cmp_deeply($data,
 			  [
 				[

--- a/t/unit-http-mix.t
+++ b/t/unit-http-mix.t
@@ -1,0 +1,80 @@
+=pod
+
+=encoding utf-8
+
+=head1 PURPOSE
+
+Unit test that Test::FITesque::RDF transforms HTTP data correctly from RDF
+
+=head1 AUTHOR
+
+Kjetil Kjernsmo E<lt>kjetilk@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is Copyright (c) 2019 by Inrupt Inc.
+
+This is free software, licensed under:
+
+  The MIT (X11) License
+
+
+=cut
+
+use strict;
+use warnings;
+use Test::Modern;
+use Test::Deep;
+use FindBin qw($Bin);
+use Data::Dumper;
+
+my $file = $Bin . '/data/http-mix.ttl';
+
+use Test::FITesque::RDF;
+
+
+my $t = object_ok(
+						sub { Test::FITesque::RDF->new(source => $file) }, 'RDF Fixture object',
+						isa => [qw(Test::FITesque::RDF Moo::Object)],
+						can => [qw(source suite transform_rdf)]);
+
+
+
+
+my $data = $t->transform_rdf;
+#warn Data::Dumper::Dumper($data);
+cmp_deeply($data,
+			  [
+				[
+				 [
+              'Internal::Fixture::HTTPList'
+				 ],
+				 [
+				  'http_req_res_list_unauthenticated',
+				  {
+					'user' => 'alice',
+					'http-requests' => ignore(),
+					'http-responses' => ignore(),
+					'description' => 'Mix HTTP and ordinary params.',
+              }
+            ]
+          ]
+        ], 'Main structure ok');
+
+my $params = $data->[0]->[1]->[1];
+
+is(scalar @{$params->{'http-requests'}}, 1, 'There is one request');
+
+foreach my $req (@{$params->{'http-requests'}}) {
+  object_ok($req, 'Checking request object',
+				isa => ['HTTP::Request'],
+				can => [qw(method uri headers content)]
+			  );
+}
+
+is(${$params->{'http-requests'}}[0]->method, 'GET', 'Second method is GET');
+
+is(scalar @{$params->{'http-responses'}}, 1, 'There is one response');
+
+done_testing;
+


### PR DESCRIPTION
This allows mixing the basic parameter style, where key-value parameters are passed, and where HTTP-requests and responses are passed. 