### PR TITLE
Group requests and responses; rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ The literal given in `test:purpose` above is passed on as with the
 
 ## RDF EXAMPLE
 
-The below example starts with prefix declarations. Since this is a
-pre-release, some of the prefixes are preliminary examples. Then, the
+The below example starts with prefix declarations. Then, the
 tests in the fixture table are listed explicitly. Only tests mentioned
 using the `test:fixtures` predicate will be used. Tests may be an RDF
 List, in which case, the tests will run in the specified sequence, if
@@ -124,9 +123,12 @@ lists of HTTP request-response objects. Both mechanisms may be used.
 The key of the hashref passed as arguments will be the local part of
 the predicate used in the description (i.e. the part after the colon
 in e.g. `my:all`). It is up to the test writer to mint the URIs of
-the parameters, and the `param_base` is used to set indicate the
-namespace, so that the local part can be resolved, if wanted. The
-resolution itself happens in [URI::NamespaceMap](https://metacpan.org/pod/URI::NamespaceMap).
+the parameters.
+
+The test writer may optionally use a `param_base` to indicate the
+namespace, in which case the the local part is resolved by the
+framework, using [URI::NamespaceMap](https://metacpan.org/pod/URI::NamespaceMap). If `param_base` is not given,
+the full URI will be passed to the test script.
 
     @prefix test: <http://ontologi.es/doap-tests#> .
     @prefix deps: <http://ontologi.es/doap-deps#>.
@@ -166,18 +168,101 @@ resolution itself happens in [URI::NamespaceMap](https://metacpan.org/pod/URI::N
 ### HTTP request-response lists
 
 To allow testing HTTP-based interfaces, this module also allows the
-construction of two ordered lists, one with HTTP requests, the other
-with HTTP responses. With those, the framework will construct
-[HTTP::Request](https://metacpan.org/pod/HTTP::Request) and [HTTP::Response](https://metacpan.org/pod/HTTP::Response) objects respectively. In tests
-scripts, the request objects will typically be passed to the
-[LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent) as input, and then the response from the remote
-server will be compared with the expected [HTTP::Response](https://metacpan.org/pod/HTTP::Response)s made by
-the test fixture. These will then be passed as arrayrefs below the
-`-special` key with the keys `http-requests` and `http-responses`
-respectively.
+construction of an ordered list of HTTP requests and response pairs.
+With those, the framework will construct [HTTP::Request](https://metacpan.org/pod/HTTP::Request) and
+[HTTP::Response](https://metacpan.org/pod/HTTP::Response) objects. In tests scripts, the request
+objects will typically be passed to the [LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent) as input,
+and then the response from the remote server will be compared with the
+asserted [HTTP::Response](https://metacpan.org/pod/HTTP::Response)s made by the test fixture.
 
-This gets more complex, please see the test data file
-`t/data/http-list.ttl` file for example.
+We will go through an example in chunks:
+
+    @prefix test: <http://ontologi.es/doap-tests#> .
+    @prefix deps: <http://ontologi.es/doap-deps#>.
+    @prefix httph:<http://www.w3.org/2007/ont/httph#> .
+    @prefix http: <http://www.w3.org/2007/ont/http#> .
+    @prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+    @prefix :     <http://example.org/test#> .
+
+    :test_list a test:FixtureTable ;
+       test:fixtures :public_writeread_unauthn_alt .
+
+    :public_writeread_unauthn_alt a test:AutomatedTest ;
+       test:purpose "To test if we can write first using HTTP PUT then read with GET"@en ;
+       test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
+       test:params [
+           test:steps (
+               [
+                   test:request :public_writeread_unauthn_alt_put_req ;
+                   test:response_assertion :public_writeread_unauthn_alt_put_res
+               ]
+               [
+                   test:request :public_writeread_unauthn_alt_get_req ;
+                   test:response_assertion :public_writeread_unauthn_alt_get_res
+               ]
+           )
+       ] .
+
+    <http://example.org/httplist#http_req_res_list_unauthenticated> a nfo:SoftwareItem ;
+       deps:test-requirement "Example::Fixture::HTTPList"^^deps:CpanId ;
+       nfo:definesFunction "http_req_res_list_unauthenticated" .
+
+In the above, after the prefixes, a single test is declared using the
+`test:fixtures` predicate, linking to a description of the test. The
+test is then described as an &lt;test:AutomatedTest>, and it's purpose is
+declared. It then links to its concrete implementation, which is given
+in the last three triples in the above.
+
+Then, the parameterization is started. In this example, there are two
+HTTP request-response pairs, which are given as a list object to the
+`test:steps` predicate.
+
+To link the request, the `test:request` predicate is used, to link
+the asserted response, the `test:response_assertion` predicate is
+used.
+
+Next, we look into the actual request and response messages linked from the above:
+
+    :public_writeread_unauthn_alt_put_req a http:RequestMessage ;
+       http:method "PUT" ;
+       httph:content_type "text/turtle" ;
+       http:content "</public/foobar.ttl#dahut> a <http://example.org/Cryptid> ." ;
+       http:requestURI </public/foobar.ttl> .
+
+    :public_writeread_unauthn_alt_put_res a http:ResponseMessage ;
+       http:status 201 .
+
+    :public_writeread_unauthn_alt_get_req a http:RequestMessage ;
+       http:method "GET" ;
+       http:requestURI </public/foobar.ttl> .
+
+    :public_writeread_unauthn_alt_get_res a http:ResponseMessage ;
+       httph:accept_post  "text/turtle", "application/ld+json" ;
+       httph:content_type "text/turtle" .
+
+These should be self-explanatory, but note that headers are given with
+lower-case names and underscores. They will be transformed to headers
+by replacing underscores with dashes and upcase the first letters.
+
+This module will transform the above to data structures that are
+suitable to be passed to [Test::Fitesque](https://metacpan.org/pod/Test::Fitesque), and the above will appear as
+
+    {
+           '-special' => {
+                                                   'http-pairs' => [
+                                      {
+                                                                                         'request'  => ... ,
+                                                                                         'response' => ... ,
+                                      },
+                                      { ... }
+                                     ]
+                                                                                    },
+                                                   'description' => 'To test if we can write first using HTTP PUT then read with GET'
+                                             },
+    }
+
+Note that there are more examples in this module's test suite in the
+`t/data/` directory.
 
 You may maintain client state in a test script (i.e. for one
 `test:AutomatedTest`, as it is simply one script, so the result of
@@ -196,7 +281,7 @@ for example:
 
 This makes it possible to use a Perl regular expression, which can be
 executed in a test script if desired. If present, it will supply
-another arrayref to the `-special` key with the key `regex-fields`
+another hashref to the `http-pairs` key with the key `regex-fields`
 containing hashrefs with the header field that had a correspondiing
 object datatyped regex as key and simply `1` as value.
 

--- a/lib/Test/FITesque/RDF.pm
+++ b/lib/Test/FITesque/RDF.pm
@@ -127,6 +127,7 @@ sub transform_rdf {
 				# Within each pair, there will be both requests and responses
 				my $req = HTTP::Request->new;
 				my $res = HTTP::Response->new;
+				my $regex_headers = {};
 				while (my $pair = $pair_iter->next) {
 				  # First, do requests
 				  my $req_entry_iter = $model->get_quads($pair->value('request'));
@@ -156,7 +157,6 @@ sub transform_rdf {
 
 				  # Now, do asserted responses
 				  my $res_entry_iter = $model->get_quads($pair->value('response_assertion'));
-				  my $regex_headers = {};
 				  while (my $res_data = $res_entry_iter->next) {
 					 my $local_header = $ns->httph->local_part($res_data->predicate);
 					 if ($res_data->predicate->equals($ns->http->status)) {
@@ -172,7 +172,7 @@ sub transform_rdf {
 				}
 				$result = { 'request' => $req,
 								'response' => $res,
-							 };#				'regex_headers' => $regex_headers };
+								'regex-fields' => $regex_headers };
 				
 				push(@pairs, $result);
 			 }

--- a/lib/Test/FITesque/RDF.pm
+++ b/lib/Test/FITesque/RDF.pm
@@ -102,7 +102,7 @@ sub transform_rdf {
 							  triplepattern($test_uri, iri($ns->test->purpose->as_string), variable('description')),
 							  triplepattern($test_uri, iri($ns->test->params->as_string), variable('paramid')));
 
-	 my $e = Attean::SimpleQueryEvaluator->new( model => $model, default_graph => $graph_id );
+	 my $e = Attean::SimpleQueryEvaluator->new( model => $model, default_graph => $graph_id, ground_blanks => 1 );
 	 my $test_iter = $e->evaluate( $test_bgp, $graph_id); # Each row will correspond to one test
 
 	 while (my $test = $test_iter->next) {
@@ -120,17 +120,14 @@ sub transform_rdf {
 			 # There exists a list of HTTP requests and responses
 			 my $steps_iter = $model->get_list($graph_id, $pairs_head);
 			 while (my $pairs_subject = $steps_iter->next) {
-				warn $pairs_subject->value;
 				my $pairs_bgp = bgp(triplepattern($pairs_subject, iri($ns->test->request->as_string), variable('request')),
 										  triplepattern($pairs_subject, iri($ns->test->response_assertion->as_string), variable('response_assertion')));
-				warn Dumper($pairs_bgp);
 				my $pair_iter = $e->evaluate( $pairs_bgp, $graph_id); # Each row will correspond to one request-response pair
 				my $result;
 				# Within each pair, there will be both requests and responses
 				my $req = HTTP::Request->new;
 				my $res = HTTP::Response->new;
 				while (my $pair = $pair_iter->next) {
-				  warn "Req: " . $pair->value('request')->value . " Res: " . $pair->value('response_assertion')->value;
 				  # First, do requests
 				  my $req_entry_iter = $model->get_quads($pair->value('request'));
 				  while (my $req_data = $req_entry_iter->next) {

--- a/lib/Test/FITesque/RDF.pm
+++ b/lib/Test/FITesque/RDF.pm
@@ -5,7 +5,7 @@ use warnings;
 package Test::FITesque::RDF;
 
 our $AUTHORITY = 'cpan:KJETILK';
-our $VERSION   = '0.012';
+our $VERSION   = '0.013_01';
 
 use Moo;
 use Attean::RDF;

--- a/meta/changes.pret
+++ b/meta/changes.pret
@@ -1,5 +1,14 @@
 # This file acts as the project's changelog.
 
+`Test-FITesque-RDF 0.013_01 cpan:KJETILK`
+    issued  2019-09-23;
+    label   "Improve the RDF" ;
+    changeset [
+        dcs:versus `Test-FITesque-RDF 0.012 cpan:KJETILK`;
+        item [ rdfs:label "Improve documentation."; a dcs:Documentation; ] ;
+	item [ rdfs:label "Restructure HTTP request-response pair parameterization."; a dcs:BackCompat; ]
+    ] .
+
 `Test-FITesque-RDF 0.012 cpan:KJETILK`
     issued  2019-08-26;
     label   "Passing URIs as parameters" ;

--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -11,7 +11,7 @@
     :runtime-requirement    [ :on "LWP::UserAgent"^^:CpanId ];
     :runtime-requirement    [ :on "Types::Path::Tiny"^^:CpanId ];
     :runtime-requirement    [ :on "Moo 1.006000"^^:CpanId ];
-    :runtime-requirement    [ :on "Attean 0.023"^^:CpanId ];
+    :runtime-requirement    [ :on "Attean 0.024"^^:CpanId ];
     :runtime-requirement    [ :on "Try::Tiny"^^:CpanId ];
     :runtime-requirement    [ :on "Types::Standard"^^:CpanId ];
     :runtime-requirement    [ :on "Types::URI"^^:CpanId ];

--- a/t/data/http-list-multi.ttl
+++ b/t/data/http-list-multi.ttl
@@ -15,26 +15,26 @@
     test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
         test:requests ( <#public-writeread-unauthn-alt-put-req> <#public-writeread-unauthn-alt-get-req> ) ;
-        test:responses ( <#public-writeread-unauthn-alt-put-res> <#public-writeread-unauthn-alt-get-res> ) 
-                ] .
-                
+        test:responses ( <#public-writeread-unauthn-alt-put-res> <#public-writeread-unauthn-alt-get-res> )
+    ] .
+
 
 <#public-writeread-unauthn-alt-put-req> a http:RequestMessage ;
-            http:method "PUT" ;
-            httph:content_type "text/turtle" ;
-            http:content "</public/foobar.ttl#dahut> a <http://example.org/Cryptid> ." ;
-            http:requestURI </public/foobar.ttl> .
-          
+    http:method "PUT" ;
+    httph:content_type "text/turtle" ;
+    http:content "</public/foobar.ttl#dahut> a <http://example.org/Cryptid> ." ;
+    http:requestURI </public/foobar.ttl> .
+
 <#public-writeread-unauthn-alt-put-res> a http:ResponseMessage ;
     http:status 201 .
 
 <#public-writeread-unauthn-alt-get-req> a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </public/foobar.ttl> .
-            
+
 <#public-writeread-unauthn-alt-get-res> a http:ResponseMessage ;
     httph:content_type "text/turtle" .
-            
+
 
 
 <#public-cors-origin-set> a test:AutomatedTest  ;
@@ -42,20 +42,20 @@
     test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
         test:requests ( <#public-cors-origin-set-req> ) ;
-        test:responses ( <#public-cors-origin-set-res> ) 
-                ] .
-                
+        test:responses ( <#public-cors-origin-set-res> )
+    ] .
+
 <#public-cors-origin-set-req> a http:RequestMessage ;
-                    http:method "GET" ;
-                    httph:origin <https://app.example> ;
-                    http:requestURI </public/verypublic/foobar.ttl> .
-            
+    http:method "GET" ;
+    httph:origin <https://app.example> ;
+    http:requestURI </public/verypublic/foobar.ttl> .
+
 <#public-cors-origin-set-res> a http:ResponseMessage ;
-                    http:status 200 ;    
-                    httph:access_control_allow_origin <https://app.example> ;
-                    httph:content_type "text/turtle" .
-            
+    http:status 200 ;
+    httph:access_control_allow_origin <https://app.example> ;
+    httph:content_type "text/turtle" .
+
 
 <http://example.org/httplist#http_req_res_list_unauthenticated> a nfo:SoftwareItem ;
-            deps:test-requirement "Internal::Fixture::HTTPList"^^deps:CpanId ;
-            nfo:definesFunction "http_req_res_list_unauthenticated" .
+    deps:test-requirement "Internal::Fixture::HTTPList"^^deps:CpanId ;
+    nfo:definesFunction "http_req_res_list_unauthenticated" .

--- a/t/data/http-list-multi.ttl
+++ b/t/data/http-list-multi.ttl
@@ -14,8 +14,16 @@
     test:purpose "More elaborate HTTP vocab for PUT then GET test"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
-        test:requests ( <#public-writeread-unauthn-alt-put-req> <#public-writeread-unauthn-alt-get-req> ) ;
-        test:responses ( <#public-writeread-unauthn-alt-put-res> <#public-writeread-unauthn-alt-get-res> )
+        test:steps (
+            [
+                test:request <#public-writeread-unauthn-alt-put-req> ;
+                test:response_assertion <#public-writeread-unauthn-alt-put-res>
+            ]
+            [
+                test:request <#public-writeread-unauthn-alt-get-req> ;
+                test:response_assertion <#public-writeread-unauthn-alt-get-res>
+            ]
+        )
     ] .
 
 
@@ -41,8 +49,12 @@
     test:purpose "Testing CORS header when Origin is supplied by client"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
-        test:requests ( <#public-cors-origin-set-req> ) ;
-        test:responses ( <#public-cors-origin-set-res> )
+        test:steps (
+            [
+                test:request <#public-cors-origin-set-req> ;
+                test:response_assertion <#public-cors-origin-set-res>
+            ]
+        )
     ] .
 
 <#public-cors-origin-set-req> a http:RequestMessage ;

--- a/t/data/http-list.ttl
+++ b/t/data/http-list.ttl
@@ -14,8 +14,16 @@
     test:purpose "More elaborate HTTP vocab for PUT then GET test"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
-        test:requests ( :public_writeread_unauthn_alt_put_req :public_writeread_unauthn_alt_get_req ) ;
-        test:responses ( :public_writeread_unauthn_alt_put_res :public_writeread_unauthn_alt_get_res ) 
+        test:steps (
+            [
+                test:request :public_writeread_unauthn_alt_put_req ;
+                test:response_assertion :public_writeread_unauthn_alt_put_res
+            ]
+            [
+                test:request :public_writeread_unauthn_alt_get_req ;
+                test:response_assertion :public_writeread_unauthn_alt_get_res
+            ]
+        )
     ] .
 
 

--- a/t/data/http-mix.ttl
+++ b/t/data/http-mix.ttl
@@ -17,18 +17,18 @@
         my:user "alice" ;
         test:requests ( <#public-writeread-unauthn-alt-get-req> ) ;
         test:responses ( <#public-writeread-unauthn-alt-get-res> ) 
-                ] .
-                
+    ] .
+
 
 <#public-writeread-unauthn-alt-get-req> a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </public/foobar.ttl> .
-            
+
 <#public-writeread-unauthn-alt-get-res> a http:ResponseMessage ;
-            httph:accept_post  "text/turtle", "application/ld+json" ;
-            httph:content_type "text/turtle" .
-            
+    httph:accept_post  "text/turtle", "application/ld+json" ;
+    httph:content_type "text/turtle" .
+
 
 <http://example.org/httplist#http_req_res_list_unauthenticated> a nfo:SoftwareItem ;
-            deps:test-requirement "Internal::Fixture::HTTPList"^^deps:CpanId ;
-            nfo:definesFunction "http_req_res_list_unauthenticated" .
+    deps:test-requirement "Internal::Fixture::HTTPList"^^deps:CpanId ;
+    nfo:definesFunction "http_req_res_list_unauthenticated" .

--- a/t/data/http-mix.ttl
+++ b/t/data/http-mix.ttl
@@ -15,8 +15,12 @@
     test:param_base <http://example.org/my-parameters#> ;
     test:params [
         my:user "alice" ;
-        test:requests ( <#public-writeread-unauthn-alt-get-req> ) ;
-        test:responses ( <#public-writeread-unauthn-alt-get-res> ) 
+        test:steps (
+            [
+                test:request <#public-writeread-unauthn-alt-get-req> ;
+                test:response_assertion <#public-writeread-unauthn-alt-get-res>
+            ]
+        )
     ] .
 
 

--- a/t/data/http-regex.ttl
+++ b/t/data/http-regex.ttl
@@ -21,8 +21,20 @@
     test:purpose "Test fields with regexps"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list_regex> ;
     test:params [
-        test:requests ( :check_acl_location_req :put_new_acl_req :check_result_req ) ;
-        test:responses ( :check_acl_location_res :put_new_acl_res :check_result_res )
+        test:steps (
+            [
+                test:request :check_acl_location_req ;
+                test:response_assertion :check_acl_location_res
+            ]
+            [
+                test:request :put_new_acl_req ;
+                test:response_assertion :put_new_acl_res
+            ]
+            [
+                test:request :check_result_req ;
+                test:response_assertion :check_result_res
+            ]
+        )
     ] .
 
 

--- a/t/lib/Internal/Fixture/HTTPList.pm
+++ b/t/lib/Internal/Fixture/HTTPList.pm
@@ -6,17 +6,17 @@ use parent 'Test::FITesque::Fixture';
 use Test::More ;
 use Test::Deep ;
 
-sub http_req_res_list_unauthenticated : Test : Plan(7) {
+sub http_req_res_list_unauthenticated : Test : Plan(6) {
   my ($self, $args) = @_;
   note($args->{'-special'}->{description});
   # TODO: Doesn't seem that hard to use Test::Deep for this after all
-  is(scalar @{$args->{'-special'}->{'http-requests'}}, 2, 'There are two requests');
-  is(${$args->{'-special'}->{'http-requests'}}[0]->method, 'PUT', 'First method is PUT');
-  is(${$args->{'-special'}->{'http-requests'}}[1]->method, 'GET', 'Second method is GET');
-  is(scalar @{$args->{'-special'}->{'http-responses'}}, 2, 'There are two responses');
-  is(${$args->{'-special'}->{'http-responses'}}[0]->code, '201', 'First code is 201');
-  is(${$args->{'-special'}->{'http-responses'}}[1]->content_type, 'text/turtle', 'Second ctype is turtle');
-  cmp_deeply([${$args->{'-special'}->{'http-responses'}}[1]->header('Accept-Post')], bag("text/turtle", "application/ld+json"), 'Response header field value bag comparison');
+  my @pairs = @{$args->{'-special'}->{'http-pairs'}};
+  is(scalar @pairs, 2, 'There are two request-response pairs');
+  is($pairs[0]->{request}->method, 'PUT', 'First method is PUT');
+  is($pairs[1]->{request}->method, 'GET', 'Second method is GET');
+  is($pairs[0]->{response}->code, '201', 'First code is 201');
+  is($pairs[1]->{response}->content_type, 'text/turtle', 'Second ctype is turtle');
+  cmp_deeply([$pairs[1]->{response}->header('Accept-Post')], bag("text/turtle", "application/ld+json"), 'Response header field value bag comparison');
 
 }
 

--- a/t/unit-http-list.t
+++ b/t/unit-http-list.t
@@ -53,9 +53,7 @@ cmp_deeply($data,
               'http_req_res_list_unauthenticated',
               {
 					'-special' => {
-										'regex-fields' => ignore(),
-										'http-requests' => ignore(),
-										'http-responses' => ignore(),
+										'http-pairs' => ignore(),
 										'description' => 'More elaborate HTTP vocab for PUT then GET test'
 									  },
               }
@@ -65,35 +63,30 @@ cmp_deeply($data,
 
 my $params = $data->[0]->[1]->[1]->{'-special'};
 
-is(scalar @{$params->{'http-requests'}}, 2, 'There are two requests');
+is(scalar @{$params->{'http-pairs'}}, 2, 'There are two request-response pairs');
 
-foreach my $req (@{$params->{'http-requests'}}) {
-  object_ok($req, 'Checking request object',
+foreach my $pair (@{$params->{'http-pairs'}}) {
+  object_ok($pair->{request}, 'Checking request object',
 				isa => ['HTTP::Request'],
 				can => [qw(method uri headers content)]
 			  );
-}
-
-is(${$params->{'http-requests'}}[0]->method, 'PUT', 'First method is PUT');
-is(${$params->{'http-requests'}}[1]->method, 'GET', 'Second method is GET');
-
-like(${$params->{'http-requests'}}[0]->content, qr/dahut/, 'First request has content');
-
-
-is(scalar @{$params->{'http-responses'}}, 2, 'There are two responses');
-
-foreach my $res (@{$params->{'http-responses'}}) {
-  object_ok($res, 'Checking response object',
+  object_ok($pair->{response}, 'Checking response object',
 				isa => ['HTTP::Response'],
 				can => [qw(code headers)]
 			  );
 }
 
-is(${$params->{'http-responses'}}[0]->code, '201', 'First code is 201');
-is(${$params->{'http-responses'}}[1]->content_type, 'text/turtle', 'Second ctype is turtle');
+is(${$params->{'http-pairs'}}[0]->{request}->method, 'PUT', 'First method is PUT');
+is(${$params->{'http-pairs'}}[1]->{request}->method, 'GET', 'Second method is GET');
 
-cmp_deeply([${$params->{'http-responses'}}[1]->header('Content-Type')], bag("text/turtle"), 'Response header field value bag comparison can be used for single values');
-cmp_deeply([${$params->{'http-responses'}}[1]->header('Accept-Post')], bag("text/turtle", "application/ld+json"), 'Response header field value bag comparison');
+like(${$params->{'http-pairs'}}[0]->{request}->content, qr/dahut/, 'First request has content');
+
+
+is(${$params->{'http-pairs'}}[0]->{response}->code, '201', 'First code is 201');
+is(${$params->{'http-pairs'}}[1]->{response}->content_type, 'text/turtle', 'Second ctype is turtle');
+
+cmp_deeply([${$params->{'http-pairs'}}[1]->{response}->header('Content-Type')], bag("text/turtle"), 'Response header field value bag comparison can be used for single values');
+cmp_deeply([${$params->{'http-pairs'}}[1]->{response}->header('Accept-Post')], bag("text/turtle", "application/ld+json"), 'Response header field value bag comparison');
 
 # TODO: Test retrieving content from URI
 

--- a/t/unit-http-mix.t
+++ b/t/unit-http-mix.t
@@ -58,7 +58,7 @@ cmp_deeply($data,
 										'http-pairs' =>
 										[
 										 {
-										# 'regex-fields' => ignore(),
+										  'regex-fields' => {},
 										  'request' => methods(method => 'GET'),
 										  'response' => isa('HTTP::Response'),
 										 }

--- a/t/unit-http-mix.t
+++ b/t/unit-http-mix.t
@@ -54,30 +54,29 @@ cmp_deeply($data,
 				  {
 					'user' => 'alice',
 					'-special' => {
-										'regex-fields' => ignore(),
-										'http-requests' => ignore(),
-										'http-responses' => ignore(),
-										'description' => 'Mix HTTP and ordinary params.'
-									  },
-              }
+										'description' => 'Mix HTTP and ordinary params.',
+										'http-pairs' =>
+										[
+										 {
+										# 'regex-fields' => ignore(),
+										  'request' => methods(method => 'GET'),
+										  'response' => isa('HTTP::Response'),
+										 }
+										]
+									  }
+				  }
             ]
           ]
         ], 'Main structure ok');
 
-my $params = $data->[0]->[1]->[1]->{'-special'};
+is(scalar @{$data->[0]->[1]->[1]->{'-special'}->{'http-pairs'}}, 1, 'There is one request');
 
-is(scalar @{$params->{'http-requests'}}, 1, 'There is one request');
+my $params = $data->[0]->[1]->[1]->{'-special'}->{'http-pairs'}->[0];
 
-foreach my $req (@{$params->{'http-requests'}}) {
-  object_ok($req, 'Checking request object',
-				isa => ['HTTP::Request'],
-				can => [qw(method uri headers content)]
-			  );
-}
-
-is(${$params->{'http-requests'}}[0]->method, 'GET', 'Second method is GET');
-
-is(scalar @{$params->{'http-responses'}}, 1, 'There is one response');
+object_ok($params->{request}, 'Checking request object',
+			 isa => ['HTTP::Request'],
+			 can => [qw(method uri headers content)]
+			);
 
 done_testing;
 

--- a/t/unit-http-regex.t
+++ b/t/unit-http-regex.t
@@ -54,32 +54,41 @@ cmp_deeply($data,
               'http_req_res_list_regex',
               {
 					'-special' => {
-										'http-requests' => array_each(isa("HTTP::Request")),
-										'http-responses' => array_each(isa("HTTP::Response")),
 										'description' => 'Test fields with regexps',
-										'regex-fields' => [
-																 {
-																  'Link' => 1
-																 },
-																 {},
-																 {
-																  'Other-Header' => 1,
-																  'Location' => 1
-																 }
-																],
+										'http-pairs' =>
+										[
+										 {
+										  'request' => isa("HTTP::Request"),
+										  'response' => isa("HTTP::Response"),
+										  'regex-fields' => {
+																	'Link' => 1
+																  },
+										 },
+										 {
+										  'request' => isa("HTTP::Request"),
+										  'response' => isa("HTTP::Response"),
+										  'regex-fields' => {},
+										 },
+										 {
+										  'request' => isa("HTTP::Request"),
+										  'response' => isa("HTTP::Response"),
+										  'regex-fields' => {
+																	'Other-Header' => 1,
+																	'Location' => 1
+																  }
+										 }
+										]
 									  },
               }
             ]
           ]
         ], 'Main structure ok');
 
-my $params = $data->[0]->[1]->[1]->{'-special'};
+my $params = $data->[0]->[1]->[1]->{'-special'}->{'http-pairs'};
 
-is(scalar @{$params->{'http-requests'}}, 3, 'There are three requests');
+is(scalar @{$params}, 3, 'There are three pairs');
 
-is(scalar @{$params->{'http-responses'}}, 3, 'There are three responses');
-
-like(${$params->{'http-responses'}}[0]->header('Link'), qr|;\\s|, 'Should be single escaped');
+like(${$params}[0]->header('Link'), qr|;\\s|, 'Should be single escaped');
 
 done_testing;
 

--- a/t/unit-http-regex.t
+++ b/t/unit-http-regex.t
@@ -88,7 +88,7 @@ my $params = $data->[0]->[1]->[1]->{'-special'}->{'http-pairs'};
 
 is(scalar @{$params}, 3, 'There are three pairs');
 
-like(${$params}[0]->header('Link'), qr|;\\s|, 'Should be single escaped');
+like($params->[0]->{response}->header('Link'), qr|;\\s|, 'Should be single escaped');
 
 done_testing;
 

--- a/t/unit-multi-http.t
+++ b/t/unit-multi-http.t
@@ -48,12 +48,12 @@ my $put_expect = [
 										'http-pairs' =>
 										[
 										 {
-										  'regex-fields' => {}
+										  'regex-fields' => {},
 										  'request' => methods(method => 'PUT'),
 										  'response' => methods(code => '201'),
 										 },
 										 {
-										  'regex-fields' => {}
+										  'regex-fields' => {},
 										  'request' => methods(method => 'GET'),
 										  'response' => isa('HTTP::Response')
 										 }
@@ -73,7 +73,7 @@ my $cors_expect = [
 										 'http-pairs' =>
 										 [
 										  {
-											'regex-fields' => {}
+											'regex-fields' => {},
 											'request' => methods(method => 'GET'),
 											'response' => isa('HTTP::Response')
 										  }

--- a/t/unit-multi-http.t
+++ b/t/unit-multi-http.t
@@ -48,12 +48,12 @@ my $put_expect = [
 										'http-pairs' =>
 										[
 										 {
-					#					  'regex-fields' => ignore(),
+										  'regex-fields' => {}
 										  'request' => methods(method => 'PUT'),
 										  'response' => methods(code => '201'),
 										 },
 										 {
-					#					  'regex-fields' => ignore(),
+										  'regex-fields' => {}
 										  'request' => methods(method => 'GET'),
 										  'response' => isa('HTTP::Response')
 										 }
@@ -73,7 +73,7 @@ my $cors_expect = [
 										 'http-pairs' =>
 										 [
 										  {
-							#				'regex-fields' => ignore(),
+											'regex-fields' => {}
 											'request' => methods(method => 'GET'),
 											'response' => isa('HTTP::Response')
 										  }

--- a/t/unit-multi-http.t
+++ b/t/unit-multi-http.t
@@ -44,18 +44,22 @@ my $put_expect = [
               'http_req_res_list_unauthenticated',
               {
 					'-special' => {
-										'regex-fields' => ignore(),
 										'description' => 'More elaborate HTTP vocab for PUT then GET test',
-										'http-requests' => [
-																  methods(method => 'PUT'),
-																  methods(method => 'GET')
-																 ],
-										'http-responses' => [
-																	methods(code => '201'),
-																	isa('HTTP::Response')
-																  ]
-									  },
-              }
+										'http-pairs' =>
+										[
+										 {
+					#					  'regex-fields' => ignore(),
+										  'request' => methods(method => 'PUT'),
+										  'response' => methods(code => '201'),
+										 },
+										 {
+					#					  'regex-fields' => ignore(),
+										  'request' => methods(method => 'GET'),
+										  'response' => isa('HTTP::Response')
+										 }
+										]
+									  }
+				  }
             ]
           ];
 my $cors_expect = [
@@ -66,14 +70,15 @@ my $cors_expect = [
               'http_req_res_list_unauthenticated',
               {
 					'-special' => { 'description' => 'Testing CORS header when Origin is supplied by client',
-										 'regex-fields' => ignore(),
-										 'http-requests' => [
-																	methods(method => 'GET')
-																  ],
-										 'http-responses' => [
-																	 isa('HTTP::Response')
-																	]
-									  },
+										 'http-pairs' =>
+										 [
+										  {
+							#				'regex-fields' => ignore(),
+											'request' => methods(method => 'GET'),
+											'response' => isa('HTTP::Response')
+										  }
+										 ]
+									  }
 				  }
 				]
 			  ];
@@ -82,12 +87,12 @@ my $cors_expect = [
 
 cmp_deeply($data, [$put_expect, $cors_expect], 'Check basic structure');
 
-my $cors_actual = $data->[1]->[1]->[1]->{'-special'};
+my $cors_actual = $data->[1]->[1]->[1]->{'-special'}->{'http-pairs'}->[0];
 
-ok(defined($cors_actual->{'http-requests'}->[0]->header('Origin')), 'Origin header found');
-ok(defined($cors_actual->{'http-responses'}->[0]->header('Access-Control-Allow-Origin')), 'ACAO header found');
+ok(defined($cors_actual->{'request'}->header('Origin')), 'Origin header found');
+ok(defined($cors_actual->{'response'}->header('Access-Control-Allow-Origin')), 'ACAO header found');
 
-is($cors_actual->{'http-requests'}->[0]->header('Origin'), $cors_actual->{'http-responses'}->[0]->header('Access-Control-Allow-Origin'), 'CORS echos origin');
+is($cors_actual->{'request'}->header('Origin'), $cors_actual->{'response'}->header('Access-Control-Allow-Origin'), 'CORS echos origin');
 
 
 done_testing;


### PR DESCRIPTION
This PR addresses various discussed issues, such as grouping requests and responses, renaming the response predicate, improve documentation on the framework level.

It depends on a new feature in Attean:  https://github.com/kasei/attean/pull/140 so it will need a new upstream release to be put in production.

It should resolve
https://github.com/solid/test-suite/issues/47
https://github.com/solid/test-suite/issues/50
https://github.com/solid/test-suite/issues/48
when they are implemented on the test script level and in the test suite.